### PR TITLE
fix: only trigger one `keyup` for repeated `keydown`

### DIFF
--- a/src/__tests__/keyboard/getNextKeyDef.ts
+++ b/src/__tests__/keyboard/getNextKeyDef.ts
@@ -77,6 +77,14 @@ cases(
       text: '[Control>]',
       modifiers: {releaseSelf: false},
     },
+    'keep key pressed with repeatModifier': {
+      text: '{Control>2}',
+      modifiers: {releaseSelf: false},
+    },
+    'release after repeatModifier': {
+      text: '{Control>2/}',
+      modifiers: {releaseSelf: true},
+    },
     'no releaseSelf on legacy modifier': {
       text: '{ctrl}',
       modifiers: {releaseSelf: false},
@@ -96,26 +104,23 @@ cases(
   {
     'invalid descriptor': {
       text: '{!}',
-      expectedError: 'Expected key descriptor but found "!" in "{!}"',
+      expectedError: 'but found "!" in "{!}"',
     },
     'missing descriptor': {
       text: '',
-      expectedError: 'Expected key descriptor but found "" in ""',
+      expectedError: 'but found "" in ""',
     },
     'missing closing bracket': {
       text: '{a)',
-      expectedError:
-        'Expected number or closing bracket but found ")" in "{a)"',
+      expectedError: 'but found ")" in "{a)"',
     },
-    'missing repeat modifier': {
+    'invalid repeat modifier': {
       text: '{a>e}',
-      expectedError:
-        'Expected number or closing bracket but found "e" in "{a>e}"',
+      expectedError: 'but found "e" in "{a>e}"',
     },
-    'missing bracket in repeat modifier': {
+    'missing bracket after repeat modifier': {
       text: '{a>3)',
-      expectedError:
-        'Expected number or closing bracket but found ")" in "{a>3)"',
+      expectedError: 'but found ")" in "{a>3)"',
     },
   },
 )

--- a/src/__tests__/keyboard/keyboardImplementation.ts
+++ b/src/__tests__/keyboard/keyboardImplementation.ts
@@ -16,7 +16,7 @@ test('no character input if `altKey` or `ctrlKey` is pressed', () => {
   expect(eventWasFired('input')).toBe(false)
 })
 
-describe('fire events', () => {
+describe('pressing and releasing keys', () => {
   it('fires event with releasing key twice', () => {
     const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
 
@@ -62,11 +62,14 @@ input[value="a"] - input
     userEvent.keyboard('{a>2}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
-Events fired on: input[value="a"]
+Events fired on: input[value="aa"]
 
 input[value=""] - keydown: a (97)
 input[value=""] - keypress: a (97)
 input[value="a"] - input
+input[value="a"] - keydown: a (97)
+input[value="a"] - keypress: a (97)
+input[value="aa"] - input
 `)
   })
 
@@ -75,7 +78,7 @@ input[value="a"] - input
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    userEvent.keyboard('{a>2}{/a}')
+    userEvent.keyboard('{a>2/}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
 Events fired on: input[value="aa"]
@@ -83,7 +86,6 @@ Events fired on: input[value="aa"]
 input[value=""] - keydown: a (97)
 input[value=""] - keypress: a (97)
 input[value="a"] - input
-input[value="a"] - keyup: a (97)
 input[value="a"] - keydown: a (97)
 input[value="a"] - keypress: a (97)
 input[value="aa"] - input
@@ -91,12 +93,12 @@ input[value="aa"] - keyup: a (97)
 `)
   })
 
-  it('fires event multiple times for multiple keys without releasing any of them', () => {
+  it('fires event multiple times for multiple keys', () => {
     const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
     ;(element as HTMLInputElement).focus()
     clearEventCalls()
 
-    userEvent.keyboard('{a>2}{/a}{b>2}{/b}{c>2}{/c}')
+    userEvent.keyboard('{a>2}{b>2/}{c>2}{/a}')
 
     expect(getEventSnapshot()).toMatchInlineSnapshot(`
 Events fired on: input[value="aabbcc"]
@@ -104,15 +106,12 @@ Events fired on: input[value="aabbcc"]
 input[value=""] - keydown: a (97)
 input[value=""] - keypress: a (97)
 input[value="a"] - input
-input[value="a"] - keyup: a (97)
 input[value="a"] - keydown: a (97)
 input[value="a"] - keypress: a (97)
 input[value="aa"] - input
-input[value="aa"] - keyup: a (97)
 input[value="aa"] - keydown: b (98)
 input[value="aa"] - keypress: b (98)
 input[value="aab"] - input
-input[value="aab"] - keyup: b (98)
 input[value="aab"] - keydown: b (98)
 input[value="aab"] - keypress: b (98)
 input[value="aabb"] - input
@@ -120,92 +119,10 @@ input[value="aabb"] - keyup: b (98)
 input[value="aabb"] - keydown: c (99)
 input[value="aabb"] - keypress: c (99)
 input[value="aabbc"] - input
-input[value="aabbc"] - keyup: c (99)
 input[value="aabbc"] - keydown: c (99)
 input[value="aabbc"] - keypress: c (99)
 input[value="aabbcc"] - input
-input[value="aabbcc"] - keyup: c (99)
-`)
-  })
-
-  it('fires event multiple times for multiple keys with releasing some of them', () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
-    ;(element as HTMLInputElement).focus()
-    clearEventCalls()
-
-    userEvent.keyboard('{a>2}{b>2}{/a}{/b}{c>2}')
-
-    expect(getEventSnapshot()).toMatchInlineSnapshot(`
-Events fired on: input[value="aabbc"]
-
-input[value=""] - keydown: a (97)
-input[value=""] - keypress: a (97)
-input[value="a"] - input
-input[value="a"] - keyup: a (97)
-input[value="a"] - keydown: a (97)
-input[value="a"] - keypress: a (97)
-input[value="aa"] - input
-input[value="aa"] - keydown: b (98)
-input[value="aa"] - keypress: b (98)
-input[value="aab"] - input
-input[value="aab"] - keyup: b (98)
-input[value="aab"] - keydown: b (98)
-input[value="aab"] - keypress: b (98)
-input[value="aabb"] - input
-input[value="aabb"] - keyup: a (97)
-input[value="aabb"] - keyup: b (98)
-input[value="aabb"] - keydown: c (99)
-input[value="aabb"] - keypress: c (99)
-input[value="aabbc"] - input
-`)
-  })
-
-  it('fires event multiple times and releases only last keys', () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
-    ;(element as HTMLInputElement).focus()
-    clearEventCalls()
-
-    userEvent.keyboard('{a>2}b')
-
-    expect(getEventSnapshot()).toMatchInlineSnapshot(`
-Events fired on: input[value="aab"]
-
-input[value=""] - keydown: a (97)
-input[value=""] - keypress: a (97)
-input[value="a"] - input
-input[value="a"] - keyup: a (97)
-input[value="a"] - keydown: a (97)
-input[value="a"] - keypress: a (97)
-input[value="aa"] - input
-input[value="aa"] - keydown: b (98)
-input[value="aa"] - keypress: b (98)
-input[value="aab"] - input
-input[value="aab"] - keyup: b (98)
-`)
-  })
-
-  it('fires event multiple times and releases all keys', () => {
-    const {element, getEventSnapshot, clearEventCalls} = setup(`<input/>`)
-    ;(element as HTMLInputElement).focus()
-    clearEventCalls()
-
-    userEvent.keyboard('{a>2}b{/a}')
-
-    expect(getEventSnapshot()).toMatchInlineSnapshot(`
-Events fired on: input[value="aab"]
-
-input[value=""] - keydown: a (97)
-input[value=""] - keypress: a (97)
-input[value="a"] - input
-input[value="a"] - keyup: a (97)
-input[value="a"] - keydown: a (97)
-input[value="a"] - keypress: a (97)
-input[value="aa"] - input
-input[value="aa"] - keydown: b (98)
-input[value="aa"] - keypress: b (98)
-input[value="aab"] - input
-input[value="aab"] - keyup: b (98)
-input[value="aab"] - keyup: a (97)
+input[value="aabbcc"] - keyup: a (97)
 `)
   })
 })

--- a/src/keyboard/getNextKeyDef.ts
+++ b/src/keyboard/getNextKeyDef.ts
@@ -1,5 +1,24 @@
 import {keyboardKey, keyboardOptions} from './types'
 
+enum bracketDict {
+  '{' = '}',
+  '[' = ']',
+}
+
+enum legacyModifiers {
+  'alt' = 'alt',
+  'ctrl' = 'ctrl',
+  'meta' = 'meta',
+  'shift' = 'shift',
+}
+
+enum legacyKeyMap {
+  ctrl = 'Control',
+  del = 'Delete',
+  esc = 'Escape',
+  space = ' ',
+}
+
 /**
  * Get the next key from keyMap
  *
@@ -7,9 +26,10 @@ import {keyboardKey, keyboardOptions} from './types'
  * Everything else will be interpreted as a typed character - e.g. `a`.
  * Brackets `{` and `[` can be escaped by doubling - e.g. `foo[[bar` translates to `foo[bar`.
  * Keeping the key pressed can be written as `{key>}`.
+ * When keeping the key pressed you can choose how long (how many keydown and keypress) the key is pressed `{key>3}`.
+ * You can then release the key per `{key>3/}` or keep it pressed and continue with the next key.
  * Modifiers like `{shift}` imply being kept pressed. This can be turned of per `{shift/}`.
  */
-
 export function getNextKeyDef(
   text: string,
   options: keyboardOptions,
@@ -18,159 +38,180 @@ export function getNextKeyDef(
   consumedLength: number
   releasePrevious: boolean
   releaseSelf: boolean
-  fireKeydownTimes: number
+  repeat: number
 } {
-  const bracketDict: {[key: string]: string | undefined} = {
-    '{': '}',
-    '[': ']',
+  const {
+    type,
+    descriptor,
+    consumedLength,
+    releasePrevious,
+    releaseSelf,
+    repeat,
+  } = readNextDescriptor(text)
+
+  const keyDef = options.keyboardMap.find(def => {
+    if (type === '[') {
+      return def.code?.toLowerCase() === descriptor.toLowerCase()
+    } else if (type === '{') {
+      const key = mapLegacyKey(descriptor)
+      return def.key?.toLowerCase() === key.toLowerCase()
+    }
+    return def.key === descriptor
+  }) ?? {
+    key: 'Unknown',
+    code: 'Unknown',
+    [type === '[' ? 'code' : 'key']: descriptor,
   }
-  const startModifiers = ['/']
-  const endModifiers = ['/', '>']
 
-  const startBracket = text[0] in bracketDict ? text[0] : ''
-  const startModifier =
-    startBracket && startModifiers.includes(text[1]) ? text[1] : ''
+  return {
+    keyDef,
+    consumedLength,
+    releasePrevious,
+    releaseSelf,
+    repeat,
+  }
+}
 
-  const descriptorStart = startBracket.length + startModifier.length
-  const descriptor = startBracket
-    ? text[descriptorStart] === startBracket
-      ? startBracket
-      : text.slice(descriptorStart).match(/^\w+/)?.[0]
-    : text[descriptorStart]
+function readNextDescriptor(text: string) {
+  let pos = 0
+  const startBracket =
+    text[pos] in bracketDict ? (text[pos] as keyof typeof bracketDict) : ''
 
-  if (!descriptor) {
+  pos += startBracket.length
+
+  // `foo{{bar` is an escaped char at position 3,
+  // but `foo{{{>5}bar` should be treated as `{` pressed down for 5 keydowns.
+  const startBracketRepeated = startBracket
+    ? (text.match(new RegExp(`^\\${startBracket}+`)) as RegExpMatchArray)[0]
+        .length
+    : 0
+  const isEscapedChar =
+    startBracketRepeated === 2 ||
+    (startBracket === '{' && startBracketRepeated > 3)
+
+  const type = isEscapedChar ? '' : startBracket
+
+  return {
+    type,
+    ...(type === '' ? readPrintableChar(text, pos) : readTag(text, pos, type)),
+  }
+}
+
+function readPrintableChar(text: string, pos: number) {
+  const descriptor = text[pos]
+
+  assertDescriptor(descriptor, text, pos)
+
+  pos += descriptor.length
+
+  return {
+    consumedLength: pos,
+    descriptor,
+    releasePrevious: false,
+    releaseSelf: true,
+    repeat: 1,
+  }
+}
+
+function readTag(
+  text: string,
+  pos: number,
+  startBracket: keyof typeof bracketDict,
+) {
+  const releasePreviousModifier = text[pos] === '/' ? '/' : ''
+
+  pos += releasePreviousModifier.length
+
+  const descriptor = text.slice(pos).match(/^\w+/)?.[0]
+
+  assertDescriptor(descriptor, text, pos)
+
+  pos += descriptor.length
+
+  const repeatModifier = text.slice(pos).match(/^>\d+/)?.[0] ?? ''
+
+  pos += repeatModifier.length
+
+  const releaseSelfModifier =
+    text[pos] === '/' || (!repeatModifier && text[pos] === '>') ? text[pos] : ''
+
+  pos += releaseSelfModifier.length
+
+  const expectedEndBracket = bracketDict[startBracket]
+  const endBracket = text[pos] === expectedEndBracket ? expectedEndBracket : ''
+
+  if (!endBracket) {
     throw new Error(
-      getErrorMessage('key descriptor', text[descriptorStart], text),
+      getErrorMessage(
+        [
+          !repeatModifier && 'repeat modifier',
+          !releaseSelfModifier && 'release modifier',
+          `"${expectedEndBracket}"`,
+        ]
+          .filter(Boolean)
+          .join(' or '),
+        text[pos],
+        text,
+      ),
     )
   }
 
-  const descriptorEnd = descriptorStart + descriptor.length
-  const endModifier =
-    startBracket &&
-    descriptor !== startBracket &&
-    endModifiers.includes(text[descriptorEnd])
-      ? text[descriptorEnd]
-      : ''
+  pos += endBracket.length
 
-  const endBracket =
-    !startBracket || descriptor === startBracket
-      ? ''
-      : bracketDict[startBracket] ?? ''
-
-  const repeatModifier = getRepeatModifier(
-    text,
-    descriptorEnd,
-    endModifier,
-    endBracket,
-  )
-
-  const modifiers = {
-    consumedLength: [
+  return {
+    consumedLength: pos,
+    descriptor,
+    releasePrevious: !!releasePreviousModifier,
+    repeat: repeatModifier ? Math.max(Number(repeatModifier.substr(1)), 1) : 1,
+    releaseSelf: hasReleaseSelf(
       startBracket,
-      startModifier,
       descriptor,
-      endModifier,
+      releaseSelfModifier,
       repeatModifier,
-      endBracket,
-    ]
-      .map(c => c.length)
-      .reduce((a, b) => a + b),
-
-    releasePrevious: startModifier === '/',
-    releaseSelf: hasReleaseSelf(startBracket, descriptor, endModifier),
-    fireKeydownTimes: repeatModifier ? parseInt(repeatModifier, 10) : 0,
-  }
-
-  if (isPrintableCharacter(startBracket, descriptor)) {
-    return {
-      ...modifiers,
-      keyDef: options.keyboardMap.find(k => k.key === descriptor) ?? {
-        key: descriptor,
-        code: 'Unknown',
-      },
-    }
-  } else if (startBracket === '{') {
-    const key = mapLegacyKey(descriptor)
-    return {
-      ...modifiers,
-      keyDef: options.keyboardMap.find(
-        k => k.key?.toLowerCase() === key.toLowerCase(),
-      ) ?? {key: descriptor, code: 'Unknown'},
-    }
-  } else {
-    return {
-      ...modifiers,
-      keyDef: options.keyboardMap.find(
-        k => k.code?.toLowerCase() === descriptor.toLowerCase(),
-      ) ?? {key: 'Unknown', code: descriptor},
-    }
+    ),
   }
 }
 
-function getRepeatModifier(
+function assertDescriptor(
+  descriptor: string | undefined,
   text: string,
-  descriptorEnd: number,
-  endModifier: string,
-  endBracket: string,
-) {
-  let repeatModifier = ''
-  if (endBracket) {
-    let charPosition = descriptorEnd + endModifier.length
-
-    while (text[charPosition] !== endBracket || !text[charPosition]) {
-      const maybeNumber = parseInt(text[charPosition], 10)
-      if (isNaN(maybeNumber)) {
-        throw new Error(
-          getErrorMessage(
-            'number or closing bracket',
-            text[charPosition],
-            text,
-          ),
-        )
-      }
-
-      repeatModifier += text[charPosition]
-      charPosition++
-    }
+  pos: number,
+): asserts descriptor is string {
+  if (!descriptor) {
+    throw new Error(getErrorMessage('key descriptor', text[pos], text))
   }
+}
 
-  return repeatModifier
+function getEnumValue<T>(f: Record<string, T>, key: string): T | undefined {
+  return f[key]
 }
 
 function hasReleaseSelf(
-  startBracket: string,
+  startBracket: keyof typeof bracketDict,
   descriptor: string,
-  endModifier: string,
+  releaseSelfModifier: string,
+  repeatModifier: string,
 ) {
-  if (endModifier === '/' || !startBracket) {
-    return true
+  if (releaseSelfModifier) {
+    return releaseSelfModifier === '/'
   }
+
+  if (repeatModifier) {
+    return false
+  }
+
   if (
     startBracket === '{' &&
-    ['alt', 'ctrl', 'meta', 'shift'].includes(descriptor.toLowerCase())
+    getEnumValue(legacyModifiers, descriptor.toLowerCase())
   ) {
     return false
   }
-  return endModifier !== '>'
+
+  return true
 }
 
 function mapLegacyKey(descriptor: string) {
-  return (
-    {
-      ctrl: 'Control',
-      del: 'Delete',
-      esc: 'Escape',
-      space: ' ',
-    }[descriptor] ?? descriptor
-  )
-}
-
-function isPrintableCharacter(startBracket: string, descriptor: string) {
-  return (
-    !startBracket ||
-    startBracket === descriptor ||
-    (startBracket === '{' && descriptor.length === 1)
-  )
+  return getEnumValue(legacyKeyMap, descriptor) ?? descriptor
 }
 
 function getErrorMessage(

--- a/src/keyboard/keyboardImplementation.ts
+++ b/src/keyboard/keyboardImplementation.ts
@@ -17,9 +17,9 @@ export async function keyboardImplementation(
 ): Promise<void> {
   const {document} = options
   const getCurrentElement = () => getActive(document)
-  const nextKeyDef = getNextKeyDef(text, options)
-  const {releasePrevious, fireKeydownTimes, releaseSelf} = nextKeyDef
-  const {keyDef, consumedLength} = state.repeatKey ?? nextKeyDef
+
+  const {keyDef, consumedLength, releasePrevious, releaseSelf, repeat} =
+    state.repeatKey ?? getNextKeyDef(text, options)
 
   const replace = applyPlugins(
     plugins.replaceBehavior,
@@ -31,7 +31,9 @@ export async function keyboardImplementation(
   if (!replace) {
     const pressed = state.pressed.find(p => p.keyDef === keyDef)
 
-    if (pressed) {
+    // Release the key automatically if it was pressed before.
+    // Do not release the key on iterations on `state.repeatKey`.
+    if (pressed && !state.repeatKey) {
       keyup(
         keyDef,
         getCurrentElement,
@@ -53,23 +55,31 @@ export async function keyboardImplementation(
         keypress(keyDef, getCurrentElement, options, state)
       }
 
-      if (releaseSelf) {
+      // Release the key only on the last iteration on `state.repeatKey`.
+      if (releaseSelf && repeat <= 1) {
         keyup(keyDef, getCurrentElement, options, state, unpreventedDefault)
       }
     }
   }
 
-  if (text.length > consumedLength) {
+  if (text.length > consumedLength || repeat > 1) {
     if (options.delay > 0) {
       await wait(options.delay)
     }
 
-    if (fireKeydownTimes > 0 && !state.repeatKey) {
-      state.repeatKey = {consumedLength, keyDef, times: fireKeydownTimes - 1}
-      return keyboardImplementation(text, options, state)
+    if (repeat > 1) {
+      state.repeatKey = {
+        // don't consume again on the next iteration
+        consumedLength: 0,
+        keyDef,
+        releasePrevious,
+        releaseSelf,
+        repeat: repeat - 1,
+      }
+    } else {
+      delete state.repeatKey
     }
 
-    delete state.repeatKey
     return keyboardImplementation(text.slice(consumedLength), options, state)
   }
   return void undefined

--- a/src/keyboard/types.ts
+++ b/src/keyboard/types.ts
@@ -1,3 +1,5 @@
+import {getNextKeyDef} from './getNextKeyDef'
+
 /**
  * @internal Do not create/alter this by yourself as this type might be subject to changes.
  */
@@ -38,9 +40,9 @@ export type keyboardState = {
   carryChar: string
 
   /**
-      Repeat keydown event for 'keyDef'
+      Repeat keydown and keypress event
    */
-  repeatKey?: {times: number; consumedLength: number; keyDef: keyboardKey}
+  repeatKey?: ReturnType<typeof getNextKeyDef>
 }
 
 export type keyboardOptions = {


### PR DESCRIPTION
**What**:

Rewrite how `getNextKeyDef` reads the next definition from the given input text.
Fix how repeated definitions are carried over to the next iteration in `keyboardImplementation`.

**Why**:

The `keyup` events were not dispatched as they are in the browser.

**How**:

To keep the code readable while fixing this, this change includes a complete refactoring of `getNextKeyDef`.
